### PR TITLE
don't deep link into posting guide

### DIFF
--- a/themes/bioconductor/templates/widgets/post_message.html
+++ b/themes/bioconductor/templates/widgets/post_message.html
@@ -1,6 +1,6 @@
 <div style="padding: 5px; font-size: small">
     <div>
-    See <a href="http://bioconductor.org/help/support/posting-guide/#composing" target="_blank">posting guide</a> for guidance on creating a post.<br>
+    See <a href="http://bioconductor.org/help/support/posting-guide/" target="_blank">posting guide</a> for guidance on creating a post.<br>
     This site uses markdown. See <a href="{% url 'post_view' '117436' %}" target="_blank">tutorial post</a>
         for advice on post formatting.</div>
 </div>


### PR DESCRIPTION
This link should not be a deep link but to the top of the page, e.g. the "be nice to developers" message is important and at the top of the page