### PR TITLE
Fix protocol

### DIFF
--- a/themes/bioconductor/settings.py
+++ b/themes/bioconductor/settings.py
@@ -7,7 +7,8 @@ DEBUG = True
 CUSTOM_THEME = os.path.abspath(os.path.join(BASE_DIR, 'themes', 'bioconductor'))
 
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "[bioc] "
-HTTP_PROTOCOL = "http"
+HTTP_PROTOCOL = "https"
+PROTOCOL = "https"
 
 LANGUAGE_DETECTION = ["en"]
 
@@ -18,7 +19,7 @@ TAGS_OPTIONS_FILE = os.path.join(CUSTOM_THEME, 'tags', 'tags.txt')
 # Ensure at least one tag in file is included.
 REQUIRED_TAGS = os.path.join(CUSTOM_THEME, 'tags', 'packageList.txt')
 
-REQUIRED_TAGS_URL = 'http://bioconductor.org/packages/devel/BiocViews.html#___Software'
+REQUIRED_TAGS_URL = 'https://bioconductor.org/packages/devel/BiocViews.html#___Software'
 
 # Rate to limit
 RATELIMIT_RATE = '200/d'

--- a/themes/bioconductor/templates/messages/mailing_list.html
+++ b/themes/bioconductor/templates/messages/mailing_list.html
@@ -9,10 +9,10 @@
 
     <p>You are getting this message as part of a mailing list.</p>
 
-    Activity on a post you are following on <a href="http://{{ domain }}">Bioconductor support</a>
+    Activity on a post you are following on <a href="https://{{ domain }}">Bioconductor support</a>
     <p>
-        User <a href="http://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
-        <a href="http://{{ domain }}{{ post.get_absolute_url }}">{{ post.title }}</a>:
+        User <a href="https://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
+        <a href="https://{{ domain }}{{ post.get_absolute_url }}">{{ post.title }}</a>:
     </p>
     <p>
         {{ post.html|safe }}
@@ -20,7 +20,7 @@
 
     <hr>
     <p style="color:#666666">
-        You may visit http://{{ domain }}{{ post.get_absolute_url }}
+        You may visit https://{{ domain }}{{ post.get_absolute_url }}
     </p>
 
     <p>The Bioconductor Team</p>
@@ -37,7 +37,7 @@
 
     {{ post.content|safe }}
 
-    You may visit http://{{ domain }}{{ post.get_absolute_url }}
+    You may visit https://{{ domain }}{{ post.get_absolute_url }}
 
     The Bioconductor Team
 

--- a/themes/bioconductor/templates/messages/subscription_email.html
+++ b/themes/bioconductor/templates/messages/subscription_email.html
@@ -7,10 +7,10 @@
 
 {% block html %}
 
-    Activity on a post you are following on <a href="http://{{ domain }}">Bioconductor support</a>
+    Activity on a post you are following on <a href="https://{{ domain }}">Bioconductor support</a>
     <p>
-        User <a href="http://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
-        <a href="http://{{ domain }}{{ post.get_absolute_url }}">{{ post.title }}</a>:
+        User <a href="https://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
+        <a href="https://{{ domain }}{{ post.get_absolute_url }}">{{ post.title }}</a>:
     </p>
     <p>
         {{ post.html|safe }}
@@ -18,7 +18,7 @@
 
     <hr>
     <p style="color:#666666">
-        You may visit http://{{ domain }}{{ post.get_absolute_url }}
+        You may visit https://{{ domain }}{{ post.get_absolute_url }}
     </p>
 
     <p>The Bioconductor Team</p>
@@ -33,7 +33,7 @@
 
     {{ post.content|safe }}
 
-    You may visit http://{{ domain }}{{ post.get_absolute_url }}
+    You may visit https://{{ domain }}{{ post.get_absolute_url }}
 
     The Bioconductor Team
 

--- a/themes/bioconductor/templates/messages/watched_tags.html
+++ b/themes/bioconductor/templates/messages/watched_tags.html
@@ -7,10 +7,10 @@
 
 {% block html %}
 
-    Activity on a tag you are watching on <a href="http://{{ domain }}">Bioconductor support</a>
+    Activity on a tag you are watching on <a href="https://{{ domain }}">Bioconductor support</a>
     <p>
-        User <a href="http://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
-        <a href="http://{{ domain }}{{ post.get_absolute_url }}">{{ post.title|safe }}</a>:
+        User <a href="https://{{ domain }}{{ post.author.profile.get_absolute_url }}">{{ post.author.profile.name }}</a> wrote
+        <a href="https://{{ domain }}{{ post.get_absolute_url }}">{{ post.title|safe }}</a>:
     </p>
     <p>
         {{ post.html|safe }}
@@ -18,7 +18,7 @@
 
     <hr>
     <p style="color:#666666">
-        You may visit http://{{ domain }}{{ post.get_absolute_url }}
+        You may visit https://{{ domain }}{{ post.get_absolute_url }}
     </p>
 
     <p>The Bioconductor Team</p>
@@ -33,7 +33,7 @@
 
     {{ post.content|safe }}
 
-    You may visit http://{{ domain }}{{ post.get_absolute_url }}
+    You may visit https://{{ domain }}{{ post.get_absolute_url }}
 
     The Bioconductor Team
 


### PR DESCRIPTION
Will this fix the protocol issue? 

Originally thought that the email templates were strictly in https://github.com/Bioconductor/support.bioconductor.org/tree/master/biostar/forum/templates/messages  and controlled by `You may visit {{ protocol }}://{{ domain }}{{ post.get_absolute_url }}` since I didn't see protocol defined I thought it is the PROTOCOL in the settings.py.  
Bioconductor settings.py didn't have a `PROTOCOL` but a `HTTP_PROTOCOL`.  I changed both of those from `http` to `https` but can this have other consequences besides the message? 

Afterwards,  I found the specialized email templates in `themes/bioconductor/templates/messages/` that had all the `http` specified. I changed all those to `https` so that I believe is the `real` fix.   

My debate is:  do we still keep the changes in the settings.py or should this be updated too? 